### PR TITLE
Add more graph types and interface conditions

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.9.3"
 manifest_format = "2.0"
-project_hash = "ad6b37f779e380e36f4488c0f02aa967a8de52e5"
+project_hash = "d2f8c395dadc24d1119ed4ed9a40ca5dfc612d18"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -54,6 +54,12 @@ deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 version = "1.6.0"
 
+[[deps.FileIO]]
+deps = ["Pkg", "Requires", "UUIDs"]
+git-tree-sha1 = "299dc33549f68299137e51e6d49a13b5b1da9673"
+uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+version = "1.16.1"
+
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
@@ -76,6 +82,12 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 git-tree-sha1 = "3a6d577f06ee9851c32ee03489b95db84f62505d"
 uuid = "85a1e053-f937-4924-92a5-1367d23b7b87"
 version = "0.3.0"
+
+[[deps.JLD2]]
+deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "Pkg", "PrecompileTools", "Printf", "Reexport", "Requires", "TranscodingStreams", "UUIDs"]
+git-tree-sha1 = "9bbb5130d3b4fa52846546bca4791ecbdfb52730"
+uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+version = "0.4.38"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -121,6 +133,18 @@ deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 version = "2.28.2+0"
 
+[[deps.MetaGraphs]]
+deps = ["Graphs", "JLD2", "Random"]
+git-tree-sha1 = "1130dbe1d5276cb656f6e1094ce97466ed700e5a"
+uuid = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
+version = "0.7.2"
+
+[[deps.MetaGraphsNext]]
+deps = ["Graphs", "JLD2", "SimpleTraits"]
+git-tree-sha1 = "8dd4f3f8a643d53e61ff9115749f522c35a38f3f"
+uuid = "fa8bd995-216d-47f1-8a91-f3b68fbeb377"
+version = "0.6.0"
+
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
@@ -147,6 +171,18 @@ deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 version = "1.9.2"
 
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "03b4c25b43cb84cee5c90aa9b5ea0a78fd848d2f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.0"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "00805cd429dcb4870060ff49ef443486c262e38e"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.1"
+
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -158,6 +194,17 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 [[deps.Random]]
 deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[deps.Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -175,6 +222,12 @@ deps = ["InteractiveUtils", "MacroTools"]
 git-tree-sha1 = "5d7e3f4e11935503d3ecaf7186eac40602e7d231"
 uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 version = "0.9.4"
+
+[[deps.SimpleWeightedGraphs]]
+deps = ["Graphs", "LinearAlgebra", "Markdown", "SparseArrays"]
+git-tree-sha1 = "4b33e0e081a825dbfaf314decf58fa47e53d6acb"
+uuid = "47aef6b3-ad0c-573a-a1e2-d07658019622"
+version = "1.4.0"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
@@ -217,6 +270,18 @@ version = "1.0.3"
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 version = "1.10.0"
+
+[[deps.TranscodingStreams]]
+git-tree-sha1 = "1fbeaaca45801b4ba17c251dd8603ef24801dd84"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.10.2"
+
+    [deps.TranscodingStreams.extensions]
+    TestExt = ["Test", "Random"]
+
+    [deps.TranscodingStreams.weakdeps]
+    Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,9 @@ version = "0.1.0"
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 Interfaces = "85a1e053-f937-4924-92a5-1367d23b7b87"
+MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
+MetaGraphsNext = "fa8bd995-216d-47f1-8a91-f3b68fbeb377"
+SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 
 [compat]
 Graphs = "1.8"

--- a/src/GraphsInterfaceChecker.jl
+++ b/src/GraphsInterfaceChecker.jl
@@ -3,17 +3,25 @@ module GraphsInterfaceChecker
 ## Imports
 
 using Interfaces: @interface, Arguments
-using Graphs: AbstractGraph, nv
+using Graphs: AbstractGraph, nv, ne, has_vertex, has_edge, is_directed, inneighbors, outneighbors,edges, vertices
 
 ## Individual conditions
 
-conditions_nv = ("`nv` must output an integer`" => g -> nv(g) isa Integer,)
 
-conditions_has_vertex = (
-    "`has_vertex` must output a bool`" => g -> has_vertex(g, 1) isa Bool,
-    "everyone in `vertices(g)` must exist" => g -> all(v -> has_vertex(g, v), vertices(g)),
-    "anyone beyond `vertices(g)` should not exist" =>
-        g -> !has_vertex(g, maximum(vertices(g)) + 1),
+
+conditions_nv = (
+    "`nv` must output an integer`" => g -> nv(g) isa Integer,
+    "`ne` must output an integer`" => g -> ne(g) isa Integer,
+    "`is_directed` must output a bool" => g -> is_directed(g) isa Bool,
+    
+    "every vertex in `vertices(g)` must exist" => g -> all(v -> has_vertex(g, v), vertices(g)),
+    "no vertex beyond `vertices(g)` should exist" =>
+        g -> !has_vertex(g, maximum(vertices(g), init=0) + 1),
+    "total number of outgoing edges should be equal to the total number of ingoing edges" =>
+        g -> sum([length(outneighbors(g, v)) for v in 1:nv(g)]) == sum([length(outneighbors(g, v)) for v in 1:nv(g)]),
+    "every edge in `edges(g)` must exist" => g -> all(e -> has_edge(g, e), edges(g)),
+    "edges with non-present vertex indices should not exist" => g -> !has_edge(g, 1, maximum(vertices(g), init=0) + 1) && !has_edge(g, 0, maximum(vertices(g), init=0)),
+
 )
 
 ## Mandatory and optional

--- a/test/graphs.jl
+++ b/test/graphs.jl
@@ -3,5 +3,8 @@ using GraphsInterfaceChecker
 using Interfaces
 using Test
 
-graphs = [SimpleGraph(0, 0), SimpleGraph(10, 20)]
+graphs = [SimpleGraph(0, 0), SimpleGraph(10, 20), SimpleGraph(4,6), SimpleGraph([0 1 0; 1 0 0; 0 0 0])]
 @test Interfaces.test(AbstractGraphInterface, SimpleGraph, graphs)
+
+digraphs = [SimpleDiGraph(5,20), SimpleDiGraph([1 1 0; 1 0 1; 0 0 0])]
+@test Interfaces.test(AbstractGraphInterface, SimpleDiGraph, digraphs)

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -1,0 +1,9 @@
+using GraphsInterfaceChecker
+using Graphs
+using MetaGraphs
+using Test
+
+graphs = [SimpleGraph(0, 0), SimpleGraph(10, 20), SimpleGraph(4,6), SimpleDiGraph(5,20), SimpleDiGraph([1 1 0; 1 0 1; 0 0 0]), SimpleGraph([0 1 0; 1 0 0; 0 0 0])]
+mgs = map((g) -> MetaGraph(g, 2.0), graphs)
+
+@test Interfaces.test(AbstractGraphInterface, MetaGraph, mgs)

--- a/test/metagraphsnext.jl
+++ b/test/metagraphsnext.jl
@@ -1,0 +1,22 @@
+using Graphs
+using MetaGraphsNext
+
+graph = Graph(Edge.([(1, 2), (1, 3), (2, 3)]))
+vertices_description = [:red => (255, 0, 0), :green => (0, 255, 0), :blue => (0, 0, 255)]
+edges_description = [
+    (:red, :green) => :yellow, (:red, :blue) => :magenta, (:green, :blue) => :cyan
+]
+
+g1 = MetaGraphsNext.MetaGraph(graph, vertices_description, edges_description, "additive colors")
+
+g2 = MetaGraphsNext.MetaGraph(
+    Graph();  # underlying graph structure
+    label_type=Symbol,  # color name
+    vertex_data_type=NTuple{3,Int},  # RGB code
+    edge_data_type=Symbol,  # result of the addition between two colors
+    graph_data="additive colors",  # tag for the whole graph
+)
+
+gs = [g1, g2]
+
+@test Interfaces.test(AbstractGraphInterface, MetaGraphsNext.MetaGraph, gs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,4 +5,13 @@ using Test
     @testset "Graphs.jl" begin
         include("graphs.jl")
     end
+    @testset "MetaGraphs.jl" begin
+        include("metagraphs.jl")
+    end
+    @testset "SimpleWeightedGraphs.jl" begin
+        include("simpleweightedgraphs.jl")
+    end
+    @testset "MetaGraphsNext.jl" begin
+        include("metagraphsnext.jl")
+    end
 end

--- a/test/simpleweightedgraphs.jl
+++ b/test/simpleweightedgraphs.jl
@@ -1,0 +1,18 @@
+using GraphsInterfaceChecker
+using Graphs
+using SimpleWeightedGraphs
+using Test
+
+sources = [1, 2, 1];
+destinations = [2, 3, 3];
+weights = [0.5, 0.8, 2.0];
+
+g1 = SimpleWeightedGraph(sources, destinations, weights)
+
+g2 = SimpleWeightedGraph(6)
+
+g3 = SimpleWeightedGraph(SimpleGraph([0 1; 1 0]), 2)
+
+gs = [g1, g2, g3]
+
+@test Interfaces.test(AbstractGraphInterface, SimpleWeightedGraph, gs)


### PR DESCRIPTION
Graph types added
- MetaGraphs.jl
- MetaGraphsNext.jl
- SimpleWeightedGraphs

Added interface conditions:
- edge balance of a graph (sum of the outgoing edges equals to the sum of ingoing edges over all vertices)
- `has_edge` and `has_vertex` are only true for `edges(g)` and `vertices(g)`, respectively